### PR TITLE
Add Spigot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,9 @@ fabric_loader_version=0.14.22
 cloth_config_version=11.1.106
 mod_menu_version=7.2.2
 
+# Spigot
+spigot_version=1.20.1-R0.1-SNAPSHOT
+
 # Mod options
 mod_name=ArmorPoser
 mod_author=Mrbysco

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,3 +21,4 @@ rootProject.name = 'ArmorPoser'
 include("common")
 include("fabric")
 include("forge")
+include("spigot")

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id 'com.gradleup.shadow' version '8.3.0'
+    id 'java'
+    id 'io.github.patrick.remapper' version "1.4.2"
+}
+
+group = 'com.mrbysco.armorposer'
+version = project.version
+
+base {
+    archivesName = "${mod_name}-spigot-${minecraft_version}"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        name = "spigotmc-repo"
+        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+    }
+    maven {
+        name = "sonatype"
+        url = "https://oss.sonatype.org/content/groups/public/"
+    }
+}
+
+dependencies {
+    compileOnly("org.spigotmc:spigot:${spigot_version}:remapped-mojang")
+    implementation project(":common")
+}
+
+def targetJavaVersion = 17
+java {
+    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+    if (JavaVersion.current() < javaVersion) {
+        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+
+    if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
+        options.release.set(targetJavaVersion)
+    }
+}
+
+tasks.remap {
+    version.set(minecraft_version)
+    inputTask.set(shadowJar)
+    archiveClassifier.set("remapped")
+    dependsOn(shadowJar)
+}
+
+tasks.shadowJar.dependsOn(build)
+
+processResources {
+    def props = [version: version]
+    inputs.properties props
+    filteringCharset 'UTF-8'
+    filesMatching('plugin.yml') {
+        expand props
+    }
+}

--- a/spigot/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
+++ b/spigot/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
@@ -1,0 +1,34 @@
+package com.mrbysco.armorposer;
+
+import com.mrbysco.armorposer.handlers.SpigotEventHandler;
+import com.mrbysco.armorposer.handlers.SpigotSwapHandler;
+import com.mrbysco.armorposer.handlers.SpigotSyncHandler;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class ArmorPoser extends JavaPlugin {
+    public static String CHANNEL_ID_SYNC = Reference.SYNC_PACKET_ID.toString();
+    public static String CHANNEL_ID_SWAP = Reference.SWAP_PACKET_ID.toString();
+    public static String CHANNEL_ID_SCREEN = Reference.SCREEN_PACKET_ID.toString();
+
+    FileConfiguration config = getConfig();
+
+    @Override
+    public void onEnable() {
+        config.addDefault("enableConfigGui", true);
+        config.addDefault("enableNameTags", true);
+        config.options().copyDefaults(true);
+        saveConfig();
+
+        this.getServer().getMessenger().registerOutgoingPluginChannel(this, CHANNEL_ID_SCREEN);
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, CHANNEL_ID_SYNC, new SpigotSyncHandler());
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, CHANNEL_ID_SWAP, new SpigotSwapHandler());
+        this.getServer().getPluginManager().registerEvents(new SpigotEventHandler(this), this);
+    }
+
+    @Override
+    public void onDisable() {
+        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+        this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
+    }
+}

--- a/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotEventHandler.java
+++ b/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotEventHandler.java
@@ -1,0 +1,55 @@
+package com.mrbysco.armorposer.handlers;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import com.mrbysco.armorposer.ArmorPoser;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class SpigotEventHandler implements Listener {
+
+    ArmorPoser pluginInstance;
+
+    public SpigotEventHandler(ArmorPoser pluginInstance) {
+        this.pluginInstance = pluginInstance;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractAtEntityEvent event) {
+        Entity target = event.getRightClicked();
+        if (target instanceof ArmorStand armorStand && event.getHand().equals(EquipmentSlot.HAND))
+        {
+            FileConfiguration config = this.pluginInstance.getConfig();
+            Player player = event.getPlayer();
+
+            if (config.getBoolean("enableConfigGui") && player.isSneaking())
+            {
+                ByteArrayDataOutput out = ByteStreams.newDataOutput();
+                out.writeInt(armorStand.getEntityId());
+
+                // channelid should be Reference.SCREEN_PACKET_ID.atoString(), but that causes
+                // Cannot access net.minecraft.resources.ResourceLocation
+                // and I don't know how to fix that in Spigot
+                player.sendPluginMessage(this.pluginInstance, ArmorPoser.CHANNEL_ID_SCREEN, out.toByteArray());
+            }
+            else if (config.getBoolean("enableNameTags") && !player.isSneaking())
+            {
+                ItemStack stack = player.getInventory().getItemInMainHand();
+                if (stack != null && stack.getType().equals(Material.NAME_TAG) && stack.hasItemMeta() && stack.getItemMeta().hasDisplayName())
+                {
+                    armorStand.setCustomName(stack.getItemMeta().getDisplayName());
+                    armorStand.setCustomNameVisible(true);
+                }
+            }
+        }
+    }
+
+}

--- a/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotSwapHandler.java
+++ b/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotSwapHandler.java
@@ -1,0 +1,25 @@
+package com.mrbysco.armorposer.handlers;
+
+import com.mrbysco.armorposer.data.SwapData;
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+public class SpigotSwapHandler implements PluginMessageListener {
+    
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        final SwapData swapData = SwapData.decode(new FriendlyByteBuf(Unpooled.wrappedBuffer(message)));
+
+        final ServerLevel world = ((CraftWorld) player.getWorld()).getHandle();
+        Entity entity = world.getEntity(swapData.entityUUID());
+        if (entity instanceof ArmorStand armorStandEntity) {
+            swapData.handleData(armorStandEntity);
+        }
+    }
+}

--- a/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotSyncHandler.java
+++ b/spigot/src/main/java/com/mrbysco/armorposer/handlers/SpigotSyncHandler.java
@@ -1,0 +1,25 @@
+package com.mrbysco.armorposer.handlers;
+
+import com.mrbysco.armorposer.data.SyncData;
+import io.netty.buffer.Unpooled;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import net.minecraft.network.FriendlyByteBuf;
+
+public class SpigotSyncHandler implements PluginMessageListener {
+
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        final SyncData syncData = SyncData.decode(new FriendlyByteBuf(Unpooled.wrappedBuffer(message)));
+
+        final ServerLevel world = ((CraftWorld) player.getWorld()).getHandle();
+        final Entity entity = world.getEntity(syncData.entityUUID());
+        if(entity instanceof ArmorStand armorStand){
+            syncData.handleData(armorStand);
+        }
+    }
+}

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -1,0 +1,4 @@
+name: ArmorPoser
+version: '1.20.0-2.2.1'
+main: com.mrbysco.armorposer.ArmorPoser
+api-version: '1.20'


### PR DESCRIPTION
this will work for both Spigot and PaperMC Servers (the 1.20.1 versions, at least)

Caveats:
1. You need to use Spigots "[BuildTools](https://www.spigotmc.org/wiki/buildtools/)" to generate a "Mojang Mappings" spigot build in your local maven cache. This is needed, because of some [drama](https://www.spigotmc.org/wiki/unofficial-explanation-about-the-dmca/#dmca-takedown) that ended in a DMCA takedown
2. In the gradle config you will find a "shadowJar" plugin (and task), which just makes sure :common is packed into the spigot jar file, so the final distributable is just a single jar
3. In the gradle config you will find a "remap" plugin (and task), which replaces the mojang class/method names by the obfuscated ones that the regular builds of spigot/paper actually use (as present in the server jar mojang distributes)
4. As a result of 3 and 4, the actually usable jar will be under "build/libs/ArmorPoser-spigot-1.20.1-2.2.1-remapped.jar"
5. I don't fully understand how one publishes a spigot plugin, seems to me like one adds a "[Resource](https://www.spigotmc.org/resources/)" in their forum... However, you could also publish it to Modrinth apparently, or https://hangar.papermc.io/ for paperMC specifically, so I am not sure which of these you would want and how to go about it.

If you are willing to take this in, I can try working out a version for all branches newer than multi/1.20 as well, but 1.20.1 is the one I needed for my own use, so that is where I started.