### PR TITLE
QoL Improvements

### DIFF
--- a/common/src/main/java/com/mrbysco/armorposer/client/KeybindHandler.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/KeybindHandler.java
@@ -1,0 +1,14 @@
+package com.mrbysco.armorposer.client;
+
+import com.mrbysco.armorposer.platform.Services;
+import net.minecraft.client.KeyMapping;
+import org.lwjgl.glfw.GLFW;
+
+public class KeybindHandler {
+	public static final KeyMapping DEFER_CONTROL_KEY = Services.PLATFORM.registerKeyMapping(
+			new KeyMapping("armorposer.keybind.deferControl", GLFW.GLFW_KEY_LEFT_ALT, "armorposer.keybinds"));
+
+	public static void loadClass() {
+	}
+
+}

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorGlowScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorGlowScreen.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ArmorGlowScreen extends Screen {
+public class ArmorGlowScreen extends MoveableScreen {
 	private static final int PADDING = 6;
 
 	private ArmorGlowWidget armorListWidget;

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorPosesScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorPosesScreen.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ArmorPosesScreen extends Screen {
+public class ArmorPosesScreen extends MoveableScreen {
 	private enum SortType {
 		NORMAL,
 		A_TO_Z,

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorStandScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/ArmorStandScreen.java
@@ -33,7 +33,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.phys.Vec3;
 
-public class ArmorStandScreen extends Screen {
+public class ArmorStandScreen extends MoveableScreen {
 	private static final WidgetSprites MIRROR_POSE_SPRITES = new WidgetSprites(
 			ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "widget/mirror_pose"), ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "widget/mirror_pose_highlighted")
 	);

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/DeletePoseScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/DeletePoseScreen.java
@@ -8,7 +8,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 
-public class DeletePoseScreen extends Screen {
+public class DeletePoseScreen extends MoveableScreen {
 	private final ArmorStandScreen parentScreen;
 	private Button deleteButton;
 	private final PoseListWidget.ListEntry entry;

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/MoveableScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/MoveableScreen.java
@@ -1,0 +1,123 @@
+package com.mrbysco.armorposer.client.gui;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mrbysco.armorposer.mixin.KeyMappingAccessor;
+import com.mrbysco.armorposer.mixin.MouseHandleAccessor;
+import com.mrbysco.armorposer.platform.Services;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import org.lwjgl.glfw.GLFW;
+
+public abstract class MoveableScreen extends Screen {
+    private static final KeyMapping DEFER_CONTROL_KEY = Services.PLATFORM.registerKeyMapping(new KeyMapping("armorposer.keybind.deferControl", GLFW.GLFW_KEY_LEFT_ALT, "armorposer.keybinds"));
+
+    private double mouseX;
+    private double mouseY;
+    private boolean isPressDown = false;
+
+    private boolean wasDeferred = false;
+    protected MoveableScreen(Component title) {
+        super(title);
+    }
+
+    @Override
+    public void afterKeyboardAction() {
+        super.afterKeyboardAction();
+        this.isPressDown = true;
+    }
+
+    @Override
+    public void removed() {
+        this.tickRelease();
+        super.removed();
+    }
+
+    @Override
+    public boolean keyPressed(int key, int scanCode, int modifiers) {
+        boolean isPressDown = this.isPressDown;
+        this.isPressDown = false;
+
+        //If a child is selected, just escape the text box when pressing escape
+        if (key == GLFW.GLFW_KEY_ESCAPE) {
+            for (var child : this.children()) {
+                if (child.isFocused()) {
+                    child.setFocused(false);
+                    return true;
+                }
+            }
+        }
+
+        boolean consumed = super.keyPressed(key, scanCode, modifiers);
+        if (consumed)
+            return true;
+
+        this.updateKeybind();
+        if (DEFER_CONTROL_KEY.isDown()) {
+            //Else consume it ourselves
+            if (!this.wasDeferred) {
+                var mouseHandle = this.minecraft.mouseHandler;
+                this.wasDeferred = true;
+                this.mouseX = mouseHandle.xpos();
+                this.mouseY = mouseHandle.ypos();
+                mouseHandle.setIgnoreFirstMove();
+                ((MouseHandleAccessor)mouseHandle).setMouseGrabbed(true);
+                InputConstants.grabOrReleaseMouse(this.minecraft.getWindow().getWindow(), 212995, ((double) this.minecraft.getWindow().getScreenWidth() / 2), ((double) this.minecraft.getWindow().getScreenHeight() / 2));
+            }
+
+            var keyEntry = InputConstants.getKey(key, scanCode);
+            if (isPressDown) {
+                KeyMapping.set(keyEntry, true);
+                KeyMapping.click(keyEntry);
+            } else {
+                KeyMapping.set(keyEntry, false);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void tickRelease() {
+        if (this.wasDeferred) {
+            this.wasDeferred = false;
+            this.minecraft.mouseHandler.setIgnoreFirstMove();
+            ((MouseHandleAccessor)this.minecraft.mouseHandler).setMouseGrabbed(false);
+            InputConstants.grabOrReleaseMouse(this.minecraft.getWindow().getWindow(), 212993, this.mouseX, this.mouseY);
+            InputConstants.grabOrReleaseMouse(this.minecraft.getWindow().getWindow(), 212993, this.mouseX, this.mouseY);
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        //Deselect focused entry if clicked and nothing hit
+        if (super.mouseClicked(mouseX, mouseY, button)) {
+            return true;
+        }
+        for (var child : this.children()) {
+            if (child.isFocused()) {
+                child.setFocused(false);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean keyReleased(int key, int scanCode, int modifiers) {
+        this.updateKeybind();
+        if (!DEFER_CONTROL_KEY.isDown()) {
+            this.tickRelease();
+        }
+        return super.keyReleased(key, scanCode, modifiers);
+    }
+
+    private void updateKeybind() {
+        var key = ((KeyMappingAccessor)DEFER_CONTROL_KEY).getKey();
+        if (key.getType() == InputConstants.Type.KEYSYM && key.getValue() != InputConstants.UNKNOWN.getValue()) {
+            DEFER_CONTROL_KEY.setDown(InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), key.getValue()));
+        }
+    }
+
+    public static void earlyInit() {}
+}

--- a/common/src/main/java/com/mrbysco/armorposer/client/gui/SavePoseScreen.java
+++ b/common/src/main/java/com/mrbysco/armorposer/client/gui/SavePoseScreen.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 
-public class SavePoseScreen extends Screen {
+public class SavePoseScreen extends MoveableScreen {
 	private final ArmorStandScreen parentScreen;
 	private Button saveButton;
 	private EditBox nameField;

--- a/common/src/main/java/com/mrbysco/armorposer/mixin/KeyMappingAccessor.java
+++ b/common/src/main/java/com/mrbysco/armorposer/mixin/KeyMappingAccessor.java
@@ -1,0 +1,12 @@
+package com.mrbysco.armorposer.mixin;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KeyMapping.class)
+public interface KeyMappingAccessor {
+    @Accessor
+    InputConstants.Key getKey();
+}

--- a/common/src/main/java/com/mrbysco/armorposer/mixin/KeyMappingAccessor.java
+++ b/common/src/main/java/com/mrbysco/armorposer/mixin/KeyMappingAccessor.java
@@ -7,6 +7,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(KeyMapping.class)
 public interface KeyMappingAccessor {
-    @Accessor
-    InputConstants.Key getKey();
+    @Accessor("key")
+    InputConstants.Key armorposer$getKey();
 }

--- a/common/src/main/java/com/mrbysco/armorposer/mixin/MouseHandleAccessor.java
+++ b/common/src/main/java/com/mrbysco/armorposer/mixin/MouseHandleAccessor.java
@@ -1,0 +1,11 @@
+package com.mrbysco.armorposer.mixin;
+
+import net.minecraft.client.MouseHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MouseHandler.class)
+public interface MouseHandleAccessor {
+    @Accessor
+    void setMouseGrabbed(boolean value);
+}

--- a/common/src/main/java/com/mrbysco/armorposer/mixin/MouseHandleAccessor.java
+++ b/common/src/main/java/com/mrbysco/armorposer/mixin/MouseHandleAccessor.java
@@ -6,6 +6,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(MouseHandler.class)
 public interface MouseHandleAccessor {
-    @Accessor
-    void setMouseGrabbed(boolean value);
+    @Accessor("mouseGrabbed")
+    void armorposer$setMouseGrabbed(boolean value);
 }

--- a/common/src/main/java/com/mrbysco/armorposer/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/com/mrbysco/armorposer/platform/services/IPlatformHelper.java
@@ -1,6 +1,7 @@
 package com.mrbysco.armorposer.platform.services;
 
 import com.mrbysco.armorposer.data.SwapData;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.decoration.ArmorStand;
 
@@ -46,4 +47,10 @@ public interface IPlatformHelper {
 	 * @return The mod version
 	 */
 	String getModVersion();
+
+	/**
+	 * Register a keyboard binding
+	 * @return bound KeyMapping
+	 */
+	KeyMapping registerKeyMapping(KeyMapping mapping);
 }

--- a/common/src/main/java/com/mrbysco/armorposer/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/com/mrbysco/armorposer/platform/services/IPlatformHelper.java
@@ -53,4 +53,9 @@ public interface IPlatformHelper {
 	 * @return bound KeyMapping
 	 */
 	KeyMapping registerKeyMapping(KeyMapping mapping);
+
+	/**
+	 * Executed when a moveable screen is opened or closed
+	 */
+	void onMoveableScreen(boolean close);
 }

--- a/common/src/main/resources/assets/armorposer/lang/en_us.json
+++ b/common/src/main/resources/assets/armorposer/lang/en_us.json
@@ -115,5 +115,7 @@
   "text.autoconfig.armorposer.option.general.resizeWhitelist.@Tooltip": "List of players that are allowed to resize the Armor Stand when restrictResizeToOP is enabled",
   "text.autoconfig.armorposer.option.general.restrictResizeToOP": "Restrict Resize To OP",
   "text.autoconfig.armorposer.option.general.restrictResizeToOP.@Tooltip": "Restrict the ability to resize the Armor Stand to server operators",
-  "text.autoconfig.armorposer.title": "Armor Poser"
+  "text.autoconfig.armorposer.title": "Armor Poser",
+  "armorposer.keybind.deferControl": "Defer Control",
+  "armorposer.keybinds": "Armor Poser"
 }

--- a/fabric/src/main/java/com/mrbysco/armorposer/ArmorPoserClient.java
+++ b/fabric/src/main/java/com/mrbysco/armorposer/ArmorPoserClient.java
@@ -1,5 +1,6 @@
 package com.mrbysco.armorposer;
 
+import com.mrbysco.armorposer.client.gui.MoveableScreen;
 import com.mrbysco.armorposer.packets.ArmorStandScreenPayload;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -8,9 +9,13 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ArmorStand;
 
 public class ArmorPoserClient implements ClientModInitializer {
+	static {
+		MoveableScreen.earlyInit();
+	}
 
 	@Override
 	public void onInitializeClient() {
+
 		ClientPlayNetworking.registerGlobalReceiver(ArmorStandScreenPayload.ID, (payload, context) -> {
 			int entityID = payload.entityID();
 

--- a/fabric/src/main/java/com/mrbysco/armorposer/ArmorPoserClient.java
+++ b/fabric/src/main/java/com/mrbysco/armorposer/ArmorPoserClient.java
@@ -1,5 +1,6 @@
 package com.mrbysco.armorposer;
 
+import com.mrbysco.armorposer.client.KeybindHandler;
 import com.mrbysco.armorposer.client.gui.MoveableScreen;
 import com.mrbysco.armorposer.packets.ArmorStandScreenPayload;
 import net.fabricmc.api.ClientModInitializer;
@@ -10,7 +11,7 @@ import net.minecraft.world.entity.decoration.ArmorStand;
 
 public class ArmorPoserClient implements ClientModInitializer {
 	static {
-		MoveableScreen.earlyInit();
+		KeybindHandler.loadClass();
 	}
 
 	@Override

--- a/fabric/src/main/java/com/mrbysco/armorposer/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/com/mrbysco/armorposer/platform/FabricPlatformHelper.java
@@ -8,8 +8,10 @@ import com.mrbysco.armorposer.packets.ArmorStandSwapPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSyncPayload;
 import com.mrbysco.armorposer.platform.services.IPlatformHelper;
 import me.shedaniel.autoconfig.AutoConfig;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.decoration.ArmorStand;
 
@@ -59,5 +61,10 @@ public class FabricPlatformHelper implements IPlatformHelper {
 	@Override
 	public String getModVersion() {
 		return FabricLoader.getInstance().getModContainer(Reference.MOD_ID).orElseThrow().getMetadata().getVersion().getFriendlyString();
+	}
+
+	@Override
+	public KeyMapping registerKeyMapping(KeyMapping mapping) {
+		return KeyBindingHelper.registerKeyBinding(mapping);
 	}
 }

--- a/fabric/src/main/java/com/mrbysco/armorposer/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/com/mrbysco/armorposer/platform/FabricPlatformHelper.java
@@ -67,4 +67,9 @@ public class FabricPlatformHelper implements IPlatformHelper {
 	public KeyMapping registerKeyMapping(KeyMapping mapping) {
 		return KeyBindingHelper.registerKeyBinding(mapping);
 	}
+
+	@Override
+	public void onMoveableScreen(boolean close) {
+		//Not needed for Fabric
+	}
 }

--- a/fabric/src/main/resources/armorposer.fabric.mixins.json
+++ b/fabric/src/main/resources/armorposer.fabric.mixins.json
@@ -8,7 +8,9 @@
     "ArmorStandMixin"
   ],
   "client": [
-    "MinecraftMixin"
+    "MinecraftMixin",
+    "MouseHandleAccessor",
+    "KeyMappingAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/forge/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
+++ b/forge/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
@@ -1,23 +1,30 @@
 package com.mrbysco.armorposer;
 
+import com.mrbysco.armorposer.client.gui.MoveableScreen;
 import com.mrbysco.armorposer.config.PoserConfig;
 import com.mrbysco.armorposer.packets.ArmorStandScreenPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSwapPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSyncPayload;
 import com.mrbysco.armorposer.packets.handler.ClientPayloadHandler;
 import com.mrbysco.armorposer.packets.handler.ServerPayloadHandler;
+import net.minecraft.client.KeyMapping;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig.Type;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mod(Reference.MOD_ID)
 public class ArmorPoser {
+	public static final List<KeyMapping> KEY_MAPPINGS = new ArrayList<>();
 
 	public ArmorPoser(IEventBus eventBus, ModContainer container, Dist dist) {
 		container.registerConfig(Type.COMMON, PoserConfig.commonSpec);
@@ -27,6 +34,9 @@ public class ArmorPoser {
 
 		if (dist.isClient()) {
 			container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
+
+			MoveableScreen.earlyInit();
+			eventBus.addListener(this::setupKeyMappings);
 		}
 	}
 
@@ -35,5 +45,10 @@ public class ArmorPoser {
 		registrar.playToClient(ArmorStandScreenPayload.ID, ArmorStandScreenPayload.CODEC, ClientPayloadHandler.getInstance()::handleScreenData);
 		registrar.playToServer(ArmorStandSwapPayload.ID, ArmorStandSwapPayload.CODEC, ServerPayloadHandler.getInstance()::handleSwapData);
 		registrar.playToServer(ArmorStandSyncPayload.ID, ArmorStandSyncPayload.CODEC, ServerPayloadHandler.getInstance()::handleSyncData);
+	}
+
+	private void setupKeyMappings(RegisterKeyMappingsEvent event) {
+		KEY_MAPPINGS.forEach(event::register);
+		KEY_MAPPINGS.clear();
 	}
 }

--- a/forge/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
+++ b/forge/src/main/java/com/mrbysco/armorposer/ArmorPoser.java
@@ -1,30 +1,25 @@
 package com.mrbysco.armorposer;
 
-import com.mrbysco.armorposer.client.gui.MoveableScreen;
+import com.mrbysco.armorposer.client.ClientHandler;
+import com.mrbysco.armorposer.client.KeybindHandler;
 import com.mrbysco.armorposer.config.PoserConfig;
 import com.mrbysco.armorposer.packets.ArmorStandScreenPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSwapPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSyncPayload;
 import com.mrbysco.armorposer.packets.handler.ClientPayloadHandler;
 import com.mrbysco.armorposer.packets.handler.ServerPayloadHandler;
-import net.minecraft.client.KeyMapping;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig.Type;
-import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Mod(Reference.MOD_ID)
 public class ArmorPoser {
-	public static final List<KeyMapping> KEY_MAPPINGS = new ArrayList<>();
 
 	public ArmorPoser(IEventBus eventBus, ModContainer container, Dist dist) {
 		container.registerConfig(Type.COMMON, PoserConfig.commonSpec);
@@ -35,8 +30,8 @@ public class ArmorPoser {
 		if (dist.isClient()) {
 			container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
 
-			MoveableScreen.earlyInit();
-			eventBus.addListener(this::setupKeyMappings);
+			KeybindHandler.loadClass();
+			eventBus.addListener(ClientHandler::setupKeyMappings);
 		}
 	}
 
@@ -45,10 +40,5 @@ public class ArmorPoser {
 		registrar.playToClient(ArmorStandScreenPayload.ID, ArmorStandScreenPayload.CODEC, ClientPayloadHandler.getInstance()::handleScreenData);
 		registrar.playToServer(ArmorStandSwapPayload.ID, ArmorStandSwapPayload.CODEC, ServerPayloadHandler.getInstance()::handleSwapData);
 		registrar.playToServer(ArmorStandSyncPayload.ID, ArmorStandSyncPayload.CODEC, ServerPayloadHandler.getInstance()::handleSyncData);
-	}
-
-	private void setupKeyMappings(RegisterKeyMappingsEvent event) {
-		KEY_MAPPINGS.forEach(event::register);
-		KEY_MAPPINGS.clear();
 	}
 }

--- a/forge/src/main/java/com/mrbysco/armorposer/client/ClientHandler.java
+++ b/forge/src/main/java/com/mrbysco/armorposer/client/ClientHandler.java
@@ -1,0 +1,16 @@
+package com.mrbysco.armorposer.client;
+
+import net.minecraft.client.KeyMapping;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClientHandler {
+	public static final List<KeyMapping> KEY_MAPPINGS = new ArrayList<>();
+
+	public static void setupKeyMappings(RegisterKeyMappingsEvent event) {
+		KEY_MAPPINGS.forEach(event::register);
+		KEY_MAPPINGS.clear();
+	}
+}

--- a/forge/src/main/java/com/mrbysco/armorposer/platform/NeoForgePlatformHelper.java
+++ b/forge/src/main/java/com/mrbysco/armorposer/platform/NeoForgePlatformHelper.java
@@ -1,5 +1,6 @@
 package com.mrbysco.armorposer.platform;
 
+import com.mrbysco.armorposer.ArmorPoser;
 import com.mrbysco.armorposer.Reference;
 import com.mrbysco.armorposer.config.PoserConfig;
 import com.mrbysco.armorposer.data.SwapData;
@@ -7,6 +8,7 @@ import com.mrbysco.armorposer.data.SyncData;
 import com.mrbysco.armorposer.packets.ArmorStandSwapPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSyncPayload;
 import com.mrbysco.armorposer.platform.services.IPlatformHelper;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.neoforged.fml.ModList;
@@ -54,5 +56,11 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
 	@Override
 	public String getModVersion() {
 		return ModList.get().getModFileById(Reference.MOD_ID).versionString();
+	}
+
+	@Override
+	public KeyMapping registerKeyMapping(KeyMapping mapping) {
+		ArmorPoser.KEY_MAPPINGS.add(mapping);
+		return mapping;
 	}
 }

--- a/forge/src/main/java/com/mrbysco/armorposer/platform/NeoForgePlatformHelper.java
+++ b/forge/src/main/java/com/mrbysco/armorposer/platform/NeoForgePlatformHelper.java
@@ -1,7 +1,7 @@
 package com.mrbysco.armorposer.platform;
 
-import com.mrbysco.armorposer.ArmorPoser;
 import com.mrbysco.armorposer.Reference;
+import com.mrbysco.armorposer.client.ClientHandler;
 import com.mrbysco.armorposer.config.PoserConfig;
 import com.mrbysco.armorposer.data.SwapData;
 import com.mrbysco.armorposer.data.SyncData;
@@ -9,10 +9,13 @@ import com.mrbysco.armorposer.packets.ArmorStandSwapPayload;
 import com.mrbysco.armorposer.packets.ArmorStandSyncPayload;
 import com.mrbysco.armorposer.platform.services.IPlatformHelper;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.neoforge.client.settings.KeyConflictContext;
 import net.neoforged.neoforge.network.PacketDistributor;
 
 import java.nio.file.Path;
@@ -60,7 +63,17 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
 
 	@Override
 	public KeyMapping registerKeyMapping(KeyMapping mapping) {
-		ArmorPoser.KEY_MAPPINGS.add(mapping);
+		ClientHandler.KEY_MAPPINGS.add(mapping);
 		return mapping;
+	}
+
+	@Override
+	public void onMoveableScreen(boolean close) {
+		Options options = Minecraft.getInstance().options;
+		options.keyUp.setKeyConflictContext(close ? KeyConflictContext.IN_GAME : KeyConflictContext.UNIVERSAL);
+		options.keyDown.setKeyConflictContext(close ? KeyConflictContext.IN_GAME : KeyConflictContext.UNIVERSAL);
+		options.keyLeft.setKeyConflictContext(close ? KeyConflictContext.IN_GAME : KeyConflictContext.UNIVERSAL);
+		options.keyRight.setKeyConflictContext(close ? KeyConflictContext.IN_GAME : KeyConflictContext.UNIVERSAL);
+		options.keyJump.setKeyConflictContext(close ? KeyConflictContext.IN_GAME : KeyConflictContext.UNIVERSAL);
 	}
 }

--- a/forge/src/main/resources/armorposer.neoforge.mixins.json
+++ b/forge/src/main/resources/armorposer.neoforge.mixins.json
@@ -6,7 +6,9 @@
   "mixins": [
   ],
   "client": [
-    "MinecraftMixin"
+    "MinecraftMixin",
+    "MouseHandleAccessor",
+    "KeyMappingAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/forge/src/main/resources/armorposer.neoforge.mixins.json
+++ b/forge/src/main/resources/armorposer.neoforge.mixins.json
@@ -6,9 +6,9 @@
   "mixins": [
   ],
   "client": [
+    "KeyMappingAccessor",
     "MinecraftMixin",
-    "MouseHandleAccessor",
-    "KeyMappingAccessor"
+    "MouseHandleAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
When clicking nothing wile there is a focused entry, defocuse that entry
When pressing escape with a focused entry, defocuse that entry
Added configurable defer control key
When defer control key is pressed, enable player movement and capture mouse
 allows continued editing of the armorstand while moving 
 
 Keyboard inputs with deferred control does not work in neoforge due to an extra check located at `net.neoforged.neoforge.client.settings.KeyConflictContext.GUI.isActive()`