### PR TITLE
Added missing translations

### DIFF
--- a/common/src/main/resources/assets/armorposer/lang/en_us.json
+++ b/common/src/main/resources/assets/armorposer/lang/en_us.json
@@ -86,6 +86,8 @@
   "armorposer.gui.tooltip.rotation": "Change rotation",
   "armorposer.gui.tooltip.scale": "Change scale",
   "armorposer.gui.tooltip.save": "Save the current pose to the user poses",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Toggle arms",
   "armorposer.gui.tooltip.size.disabled": "Size is restricted to server operators",
   "armorposer.gui.tooltip.small": "Toggle size",

--- a/common/src/main/resources/assets/armorposer/lang/es_mx.json
+++ b/common/src/main/resources/assets/armorposer/lang/es_mx.json
@@ -84,6 +84,8 @@
   "armorposer.gui.tooltip.poses": "Poses predeterminadas",
   "armorposer.gui.tooltip.rotation": "Cambiar rotación",
   "armorposer.gui.tooltip.save": "Save the current pose to the user poses",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Alternar brazos",
   "armorposer.gui.tooltip.size.disabled": "Size is restricted to server operators",
   "armorposer.gui.tooltip.small": "Alternar tamaño",

--- a/common/src/main/resources/assets/armorposer/lang/fr_fr.json
+++ b/common/src/main/resources/assets/armorposer/lang/fr_fr.json
@@ -84,6 +84,8 @@
   "armorposer.gui.tooltip.poses": "Check built-in poses",
   "armorposer.gui.tooltip.rotation": "Change rotation",
   "armorposer.gui.tooltip.save": "Save the current pose to the user poses",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Toggle arms",
   "armorposer.gui.tooltip.size.disabled": "Size is restricted to server operators",
   "armorposer.gui.tooltip.small": "Toggle size",

--- a/common/src/main/resources/assets/armorposer/lang/pt_br.json
+++ b/common/src/main/resources/assets/armorposer/lang/pt_br.json
@@ -86,6 +86,8 @@
   "armorposer.gui.tooltip.rotation": "Alterar rotação",
   "armorposer.gui.tooltip.scale": "Alterar escala",
   "armorposer.gui.tooltip.save": "Salvar a pose atual nas poses do usuário",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Alternar braços",
   "armorposer.gui.tooltip.size.disabled": "O tamanho é restrito aos operadores de servidores",
   "armorposer.gui.tooltip.small": "Alternar tamanho",

--- a/common/src/main/resources/assets/armorposer/lang/ru_ru.json
+++ b/common/src/main/resources/assets/armorposer/lang/ru_ru.json
@@ -84,6 +84,8 @@
   "armorposer.gui.tooltip.poses": "Проверить предустановленные позы",
   "armorposer.gui.tooltip.rotation": "Изменить поворот",
   "armorposer.gui.tooltip.save": "Сохранить текущую позу в пользовательские позы",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Переключить видимость рук",
   "armorposer.gui.tooltip.size.disabled": "Размер ограничен для операторов сервера",
   "armorposer.gui.tooltip.small": "Переключить размер",

--- a/common/src/main/resources/assets/armorposer/lang/zh_tw.json
+++ b/common/src/main/resources/assets/armorposer/lang/zh_tw.json
@@ -84,6 +84,8 @@
   "armorposer.gui.tooltip.poses": "Check built-in poses",
   "armorposer.gui.tooltip.rotation": "Change rotation",
   "armorposer.gui.tooltip.save": "Save the current pose to the user poses",
+  "armorposer.gui.tooltip.base_plate": "Toggle base plate",
+  "armorposer.gui.tooltip.gravity": "Toggle gravity",
   "armorposer.gui.tooltip.show_arms": "Toggle arms",
   "armorposer.gui.tooltip.size.disabled": "Size is restricted to server operators",
   "armorposer.gui.tooltip.small": "Toggle size",


### PR DESCRIPTION
Added `armorposer.gui.tooltip.gravity` and `armorposer.gui.tooltip.base_plate` to all languages.

![2025-01-05_22 53 29](https://github.com/user-attachments/assets/a194a20e-85d8-4252-8d17-c966c4253990)
![2025-01-05_22 53 34](https://github.com/user-attachments/assets/f8b0890f-474c-417b-89f2-56ee5db24ffd)
